### PR TITLE
Add Cray ARCHER Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ cd optim_m1qn3/src
 
 Edit Makefile to adjust to your platform and compiler. It is important that you use the same compiler and compiler flags here as for compiling the MITgcm. This is important to ensure that the binary files written by the MITgcm are read correctly. For me this involves choosing the correct CPP command and setting SUFF=for (because I use MacOS and this is case-insensitive in my case), but you may want to check `tutorial_global_oce_optim/build/Makefile` to see, what compilers and options you actually used. Pay attention to the values of `FC` and `FFLAGS`; the optimization flags in `FOPTIM` are usually not important.
 
+The file src/Makefile.ARCHER in this repository can be used to compile optim_m1qn3 on ARCHER, the UK national supercomputer.  
+
 ```
 make depend
 make

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cd optim_m1qn3/src
 
 Edit Makefile to adjust to your platform and compiler. It is important that you use the same compiler and compiler flags here as for compiling the MITgcm. This is important to ensure that the binary files written by the MITgcm are read correctly. For me this involves choosing the correct CPP command and setting SUFF=for (because I use MacOS and this is case-insensitive in my case), but you may want to check `tutorial_global_oce_optim/build/Makefile` to see, what compilers and options you actually used. Pay attention to the values of `FC` and `FFLAGS`; the optimization flags in `FOPTIM` are usually not important.
 
-The file src/Makefile.ARCHER in this repository can be used to compile optim_m1qn3 on ARCHER, the UK national supercomputer.  
+The file `src/Makefile.ARCHER` in this repository can be used to compile optim_m1qn3 on ARCHER, the UK national supercomputer.  
 
 ```
 make depend

--- a/src/Makefile.ARCHER
+++ b/src/Makefile.ARCHER
@@ -33,16 +33,16 @@ SRC		=       optim_main.F			\
                         ddot.F                          
 
 # default suffix for pre-processed fortran files is f
-SUFF= f
+SUFF = f
  
 # location of cpp preprocessor
-CPP= cat $< | cpp -traditional -P 
+CPP = cat $< | cpp -traditional -P 
 
 # make depend command
-MAKEDEPEND=makedepend
+MAKEDEPEND = makedepend
 
 # libraries and include directories
-LIBS=-L/opt/cray/netcdf-hdf5parallel/4.4.1.1/cray/83/lib -L/opt/cray/mpt/7.5.5/gni/mpich-cray/84/lib 
+LIBS            = 
 INCLUDEDIRS     = -I.				\
 	      	  -I../../MITgcm/verification/tutorial_global_oce_optim/build 
 LIBDIRS         =   

--- a/src/Makefile.ARCHER
+++ b/src/Makefile.ARCHER
@@ -19,8 +19,10 @@
 #
 #***********************************************************************
 
+# name of Makefile
 MAKEFILE = Makefile
-# the optimization routines.
+
+# names of the source code files for the optimization routine
 SRC		=       optim_main.F			\
 			optim_sub.F			\
 			optim_readparms.F		\
@@ -31,18 +33,18 @@ SRC		=       optim_main.F			\
                         ddot.F                          
 
 # default suffix for pre-processed fortran files is f
-SUFF= f 
+SUFF= f
+ 
 # location of cpp preprocessor
 CPP= cat $< | cpp -traditional -P 
 
+# make depend command
 MAKEDEPEND=makedepend
 
-INCLUDES=-I/opt/cray/netcdf-hdf5parallel/4.4.1.1/cray/83/include -I/opt/cray/mpt/7.5.5/gni/mpich-cray/84/include 
+# libraries and include directories
 LIBS=-L/opt/cray/netcdf-hdf5parallel/4.4.1.1/cray/83/lib -L/opt/cray/mpt/7.5.5/gni/mpich-cray/84/lib 
-
 INCLUDEDIRS     = -I.				\
 	      	  -I../../MITgcm/verification/tutorial_global_oce_optim/build 
-
 LIBDIRS         =   
 
 # name of executable (in current directory)
@@ -55,17 +57,12 @@ CPPFLAGS =  -DREAL_BYTE=4		\
 	-D_RS='double precision'	\
 	-D_d='d'  
 
-# FORTRAN compiler and its flags.
+# cray fortran compiler and flags (uses the 'large executable' version of linux_ia64_cray_archer)
 # the byte conversion flags must match those used in the  mitgcmuv compilation
-
-# cray compiler for ARCHER
 FC     =  ftn 
-LINK =  ftn 
 FFLAGS =  -h pic -dynamic 
-FOPTIM =  -O0 -hpf0 
 
-DEFINES = -DWORDLENGTH=4 -D_BYTESWAPIO -DTARGET_CRAYXT -DALLOW_USE_MPI -DHAVE_SYSTEM -DHAVE_FDATE -DHAVE_CLOC -DHAVE_SETRLSTK -DHAVE_SIGREG -DHAVE_STAT -DHAVE_NETCDF -DHAVE_FLUSH 
-
+# definitions
 SMALLF      = $(SRC:.F=.$(SUFF))
 OBJECTS     = $(SRC:.F=.o)
 
@@ -81,7 +78,7 @@ small_f: $(SMALLF)
 depend:
 	$(MAKEDEPEND) -o .$(SUFF) $(INCLUDEDIRS) $(SRC)
 
-# The normal chain of rules is (  .F - .f - .o  )
+# the normal chain of rules is (  .F - .f - .o  )
 .F.for:
 	$(CPP) $(CPPFLAGS) $(INCLUDEDIRS) > $@
 .for.o:
@@ -91,7 +88,7 @@ depend:
 .f.o:
 	$(FC) $(FFLAGS) -c $<
 
-# Cleaning options.
+# cleaning options.
 clean:
 	-rm -f *.o *.f *.for
 
@@ -103,43 +100,3 @@ CLEAN:
 	@make -f $(MAKEFILE) Clean
 	-rm -f $(EXECUTABLE)
 
-# DO NOT DELETE
-
-optim_sub.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CTRL_OPTIONS.h
-optim_sub.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/PACKAGES_CONFIG.h
-optim_sub.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_OPTIONS.h
-optim_sub.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_EEOPTIONS.h
-optim_sub.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_EEMACROS.h
-optim_sub.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/EEPARAMS.h
-optim_sub.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/SIZE.h
-optim_sub.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/ctrl.h
-optim_sub.f: optim.h m1qn3_common.h
-optim_readparms.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CTRL_OPTIONS.h
-optim_readparms.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/PACKAGES_CONFIG.h
-optim_readparms.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_OPTIONS.h
-optim_readparms.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_EEOPTIONS.h
-optim_readparms.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_EEMACROS.h
-optim_readparms.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/EEPARAMS.h
-optim_readparms.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/SIZE.h
-optim_readparms.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/ctrl.h
-optim_readparms.f: optim.h
-optim_readdata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CTRL_OPTIONS.h
-optim_readdata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/PACKAGES_CONFIG.h
-optim_readdata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_OPTIONS.h
-optim_readdata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_EEOPTIONS.h
-optim_readdata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_EEMACROS.h
-optim_readdata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/EEPARAMS.h
-optim_readdata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/SIZE.h
-optim_readdata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/ctrl.h
-optim_readdata.f: optim.h
-optim_writedata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CTRL_OPTIONS.h
-optim_writedata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/PACKAGES_CONFIG.h
-optim_writedata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_OPTIONS.h
-optim_writedata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_EEOPTIONS.h
-optim_writedata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_EEMACROS.h
-optim_writedata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/EEPARAMS.h
-optim_writedata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/SIZE.h
-optim_writedata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/ctrl.h
-optim_writedata.f: optim.h
-optim_store_m1qn3.f: m1qn3_common.h m1qn3a_common.h mlis3_common.h
-m1qn3_offline.f: m1qn3_common.h m1qn3a_common.h mlis3_common.h

--- a/src/Makefile.ARCHER
+++ b/src/Makefile.ARCHER
@@ -1,0 +1,145 @@
+#***********************************************************************
+# Makefile for the offline large scale optimization with m1qn3
+# in reverse communication mode.
+#
+# started: Martin Losch Martin.Losch@awi.de 24-Apr-2012
+#
+# changed: Dan Jones 16-Nov-2020 for UK ARCHER (http://www.archer.ac.uk/) 
+#
+# The compiler flags here match those used in the "large executable" 
+# configuration of the MITgcm build options file located in: 
+# /MITgcm/tools/build_options/linux_ia64_cray_archer
+#
+# In this instance, MITgcm was compiled using the cray compiler. 
+# On ARCHER, use the command `module load PrgEnv-cray` before compiling 
+# optim_m1qn3. 
+#
+# UK ARCHER won't be active much longer, but this file may be used as 
+# a basis for development on other Cray systems, including ARCHER2
+#
+#***********************************************************************
+
+MAKEFILE = Makefile
+# the optimization routines.
+SRC		=       optim_main.F			\
+			optim_sub.F			\
+			optim_readparms.F		\
+			optim_readdata.F		\
+			optim_writedata.F		\
+			optim_store_m1qn3.F		\
+                        m1qn3_offline.F			\
+                        ddot.F                          
+
+# default suffix for pre-processed fortran files is f
+SUFF= f 
+# location of cpp preprocessor
+CPP= cat $< | cpp -traditional -P 
+
+MAKEDEPEND=makedepend
+
+INCLUDES=-I/opt/cray/netcdf-hdf5parallel/4.4.1.1/cray/83/include -I/opt/cray/mpt/7.5.5/gni/mpich-cray/84/include 
+LIBS=-L/opt/cray/netcdf-hdf5parallel/4.4.1.1/cray/83/lib -L/opt/cray/mpt/7.5.5/gni/mpich-cray/84/lib 
+
+INCLUDEDIRS     = -I.				\
+	      	  -I../../MITgcm/verification/tutorial_global_oce_optim/build 
+
+LIBDIRS         =   
+
+# name of executable (in current directory)
+EXECUTABLE      = optim.x 
+
+# the cpp flags 
+CPPFLAGS =  -DREAL_BYTE=4		\
+	-DMAX_INDEPEND=1000000		\
+	-D_RL='double precision'	\
+	-D_RS='double precision'	\
+	-D_d='d'  
+
+# FORTRAN compiler and its flags.
+# the byte conversion flags must match those used in the  mitgcmuv compilation
+
+# cray compiler for ARCHER
+FC     =  ftn 
+LINK =  ftn 
+FFLAGS =  -h pic -dynamic 
+FOPTIM =  -O0 -hpf0 
+
+DEFINES = -DWORDLENGTH=4 -D_BYTESWAPIO -DTARGET_CRAYXT -DALLOW_USE_MPI -DHAVE_SYSTEM -DHAVE_FDATE -DHAVE_CLOC -DHAVE_SETRLSTK -DHAVE_SIGREG -DHAVE_STAT -DHAVE_NETCDF -DHAVE_FLUSH 
+
+SMALLF      = $(SRC:.F=.$(SUFF))
+OBJECTS     = $(SRC:.F=.o)
+
+.SUFFIXES:
+.SUFFIXES: .o .$(SUFF) .F
+
+all: small_f $(EXECUTABLE)
+$(EXECUTABLE): $(OBJECTS)
+	$(FC) -o $@ $(FFLAGS) $(OBJECTS) $(LIBDIRS) $(LIBS)
+
+small_f: $(SMALLF)
+
+depend:
+	$(MAKEDEPEND) -o .$(SUFF) $(INCLUDEDIRS) $(SRC)
+
+# The normal chain of rules is (  .F - .f - .o  )
+.F.for:
+	$(CPP) $(CPPFLAGS) $(INCLUDEDIRS) > $@
+.for.o:
+	$(FC) $(FFLAGS) -c $<
+.F.f:
+	$(CPP) $(CPPFLAGS) $(INCLUDEDIRS) > $@
+.f.o:
+	$(FC) $(FFLAGS) -c $<
+
+# Cleaning options.
+clean:
+	-rm -f *.o *.f *.for
+
+Clean:
+	@make -f $(MAKEFILE) clean
+	-rm -f OPWARM.*
+
+CLEAN:
+	@make -f $(MAKEFILE) Clean
+	-rm -f $(EXECUTABLE)
+
+# DO NOT DELETE
+
+optim_sub.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CTRL_OPTIONS.h
+optim_sub.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/PACKAGES_CONFIG.h
+optim_sub.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_OPTIONS.h
+optim_sub.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_EEOPTIONS.h
+optim_sub.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_EEMACROS.h
+optim_sub.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/EEPARAMS.h
+optim_sub.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/SIZE.h
+optim_sub.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/ctrl.h
+optim_sub.f: optim.h m1qn3_common.h
+optim_readparms.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CTRL_OPTIONS.h
+optim_readparms.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/PACKAGES_CONFIG.h
+optim_readparms.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_OPTIONS.h
+optim_readparms.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_EEOPTIONS.h
+optim_readparms.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_EEMACROS.h
+optim_readparms.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/EEPARAMS.h
+optim_readparms.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/SIZE.h
+optim_readparms.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/ctrl.h
+optim_readparms.f: optim.h
+optim_readdata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CTRL_OPTIONS.h
+optim_readdata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/PACKAGES_CONFIG.h
+optim_readdata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_OPTIONS.h
+optim_readdata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_EEOPTIONS.h
+optim_readdata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_EEMACROS.h
+optim_readdata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/EEPARAMS.h
+optim_readdata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/SIZE.h
+optim_readdata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/ctrl.h
+optim_readdata.f: optim.h
+optim_writedata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CTRL_OPTIONS.h
+optim_writedata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/PACKAGES_CONFIG.h
+optim_writedata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_OPTIONS.h
+optim_writedata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_EEOPTIONS.h
+optim_writedata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/CPP_EEMACROS.h
+optim_writedata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/EEPARAMS.h
+optim_writedata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/SIZE.h
+optim_writedata.f: ../../MITgcm/verification/tutorial_global_oce_optim/build/ctrl.h
+optim_writedata.f: optim.h
+optim_store_m1qn3.f: m1qn3_common.h m1qn3a_common.h mlis3_common.h
+m1qn3_offline.f: m1qn3_common.h m1qn3a_common.h mlis3_common.h


### PR DESCRIPTION
This pull request is a follow-up from issue #5. As requested, I've added the Makefile that I used to compile optim.x on ARCHER (http://www.archer.ac.uk/). I've also added a line in the README.md file about the new example Makefile. 

Thanks for your help and for making this code available @mjlosch.
