### PR TITLE
Update default "tools" folder location

### DIFF
--- a/src/makefile_templ
+++ b/src/makefile_templ
@@ -21,7 +21,7 @@ SRC        = optim_main.F		\
 	     ddot.F
 
 EXEDIR     = .
-TOOLSDIR   = ../../MITgcm/tools
+TOOLSDIR   = ../../../MITgcm/tools
 
 INCLUDES   = -I. -I_GET_BLD_DIR
 


### PR DESCRIPTION
This is the correct path if one is compiling from MITgcm/optim_m1qn3/src/