### PR TITLE
Make restarts sensitive to (possibly) increased `numiter`

### DIFF
--- a/src/m1qn3_offline.F
+++ b/src/m1qn3_offline.F
@@ -11,7 +11,7 @@ C
       subroutine m1qn3_offline
      &     (simul,prosca,ctonb,ctcab,n,x,f,g,dxmin,df1,
      &     epsg,normtype,impres,io,imode,omode,niter,nsim,
-     &     iz,dz,ndz,reverse,indic,izs,rzs,dzs)
+     &     iz,dz,ndz,reverse,indic,izs,rzs,dzs,nitermax)
 c
 c-----------------------------------------------------------------------
 c
@@ -100,7 +100,7 @@ c     arguments
 c
       character*3 normtype
       integer n,impres,io,imode(3),omode,niter,nsim,iz(5),ndz,indic,
-     &    reverse,izs(*)
+     &    reverse,izs(*),nitermax
       real rzs(*)
       double precision x(n),f,g(n),dxmin,df1,epsg,dz(ndz),dzs(*)
       external simul,prosca,ctonb,ctcab
@@ -376,7 +376,7 @@ c
      &             normtype,impres,io,imode,omode,niter,nsim,inmemo,
      &             iz(3),iz(4),iz(5),dz(id),dz(igg),dz(idiag),dz(iaux),
      &             dz(ialpha),dz(iybar),dz(isbar),reverse,reentry,indic,
-     &             izs,rzs,dzs)
+     &             izs,rzs,dzs,nitermax)
       if (reentry.gt.0) return
 c
 c---- impressions finales
@@ -409,7 +409,7 @@ c
       subroutine m1qn3a (simul,prosca,ctonb,ctcab,n,x,f,g,dxmin,df1,
      &                   epsg,normtype,impres,io,imode,omode,niter,nsim,
      &                   inmemo,m,jmin,jmax,d,gg,diag,aux,alpha,ybar,
-     &                   sbar,reverse,reentry,indic,izs,rzs,dzs)
+     &                   sbar,reverse,reentry,indic,izs,rzs,dzs,nitermax)
 c----
 c
 c     Code d optimisation proprement dit.
@@ -423,7 +423,7 @@ c
       logical inmemo
       character*3 normtype
       integer n,impres,io,imode(3),omode,niter,nsim,m,jmin,jmax,indic,
-     &    reverse,reentry,izs(*)
+     &    reverse,reentry,izs(*),nitermax
       real rzs(*)
       double precision x(n),f,g(n),dxmin,df1,epsg,d(n),gg(n),diag(n),
      &    aux(n),alpha(m),ybar(n,*),sbar(n,*),dzs(*)
@@ -474,7 +474,7 @@ c
 c
       skip_update = .false.
 c
-      itmax=niter
+      nitermax=niter
       niter=0
       isim=1
       eps1=1.d+0
@@ -831,7 +831,7 @@ c
           omode=1
           goto 1000
       endif
-      if (niter.eq.itmax) then
+      if (niter.eq.nitermax) then
           omode=4
           if (impres.ge.1) write (io,941) niter
   941     format (/" >>> m1qn3 (iteration ",i0,
@@ -892,7 +892,7 @@ c---- on poursuit les iterations
 c
       goto 100
 c
-c --- n1qn3 has finished for ever
+c --- m1qn3 has finished for ever
 c
  1000 continue
       if (reverse.ne.0) reverse = -1

--- a/src/optim_store_m1qn3.F
+++ b/src/optim_store_m1qn3.F
@@ -15,6 +15,7 @@ c
 c--   global variables
 #include "m1qn3_common.h"
 #include "m1qn3a_common.h"
+c--   itmax --> DEPRECATED: kept only for restart compatibility
 #include "mlis3_common.h"
 c--   routine arguments
       integer ndz
@@ -29,6 +30,9 @@ c--   local variables
       integer io, k
       character*(14) fname
       logical fileExists
+
+c--   Assign dummy value to (deprecated) itmax
+      itmax = -9999
 
 c--   routine body
       fname = ' '

--- a/src/optim_sub.F
+++ b/src/optim_sub.F
@@ -215,7 +215,7 @@ c     the reverse communication mode and should not be changed.
       call m1qn3_offline (simul_rc,euclid,ctonbe,ctcabe,
      &     nn,xx,objf,adxx,dxmin,df1,
      &     epsg,normtype,impres,io,imode,omode,niter,nsim,
-     &     iz,dz,ndz,reverse,indic,izs,rzs,dzs)
+     &     iz,dz,ndz,reverse,indic,izs,rzs,dzs,numiter)
       close(io)
       print *, ' OPTIM_SUB: ...........................'
       print *, ' OPTIM_SUB: returned from m1qn3_offline'


### PR DESCRIPTION
## Short description of the modifications

Formerly, m1qn3 stored the maximum number of iteration `itmax` directly in the `OPWARM.optxxxx` files, which meant that changing `numiter` in `data.optim` would have no effect on m1qn3's `itmax`. In order to make restarts with an increased maximum number of iterations work, `numiter` (from namelist 'OPTIM' in data.optim) should take precedence over `itmax`. I therefore retired `itmax` by:
- assigning `itmax` a dummy value in optim_store_m1qn3.F (rather than removing it entirely from OPWARM files for the sake of not breaking compatibility with existing restart files);
- adding new argument `nitermax` to subroutines `m1qn3_offline` and `m1qn3a` in m1qn3_offline.F;
- in `optim_sub`, calling `m1qn3_offline` with `nitermax=numiter`.

## How to perform a warm restart with an increased `numiter`

*(Here, we assume that one uses a script for automating the optimization process similar to that provided in the [README.md](https://github.com/mjlosch/optim_m1qn3/blob/master/README.md) file)*
With the new version of the code, it is possible to do a warm restart even if the initial maximum number of iterations has been reached, following the steps below:
1) Remove file `OPWARM.optxxxx` and `ecco_ctrl_MIT_CE_000.optxxxx` where `xxxx=optimcycle+1` (i.e. the highest integer). These two files have been created when executing `optim.x` for the last time, leading to the final termination of the algorithm.
2) Increase `numiter` in the `data.optim` file to the new maximum number of iterations.
3) Run `./optim.x > opt$((optimcycle+1)).txt` *by hand*.
4) In m1qn3_output.txt, remove the block starting with 'm1qn3: output mode is ', because this is the current way of detecting whether m1qn3 has finished or not (see e.g. the bash script provided in [README.md](https://github.com/mjlosch/optim_m1qn3/blob/master/README.md)).
5) Re-run the bash *orchestrating* script.

## Does this PR introduce a breaking change?

No, `OPWARM.optxxxx` files still store a dummy value (-9999) for `itmax`, which is unused.